### PR TITLE
Update README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To run the observability example:
 2. Run: `npm start`
 3. Access metrics at `http://localhost:3000/metrics`
 
+`npm start` executes this observability example. Use `npx ts-node` for the
+other examples.
+
 ### Plugin System Example
 
 Located in [`src/plugin-system/`](src/plugin-system/), this example shows how to extend the AI Agent Flow framework with custom components:
@@ -44,6 +47,12 @@ graph LR
     C --> F[Flow Execution]
     D --> F
     E --> F
+```
+
+Run with:
+
+```bash
+npx ts-node src/plugin-system/index.ts
 ```
 
 ### Streaming Example
@@ -66,40 +75,88 @@ graph TD
 To run the streaming example:
 
 1. Set up your OpenAI API key in `.env`
-2. Run: `npm start`
+2. Run: `npx ts-node src/streaming/index.ts`
 
 
 ### Advanced Example
 
 Located in [`src/advanced/`](src/advanced/), this example shows conditional branching with a `DecisionNode`.
 
+Run with:
+
+```bash
+npx ts-node src/advanced/index.ts
+```
+
 ### Chatbot Example
 
 Located in [`src/chatbot/`](src/chatbot/), this is a tiny chatbot that tracks conversation history.
+
+Run with:
+
+```bash
+npx ts-node src/chatbot/index.ts
+```
 
 ### Data Pipeline Example
 
 Located in [`src/data-pipeline/`](src/data-pipeline/), this example processes items in batches using `BatchNode`.
 
+Run with:
+
+```bash
+npx ts-node src/data-pipeline/index.ts
+```
+
 ### Debug UI Example
 
 Located in [`src/debug-ui/`](src/debug-ui/), this example attaches an update handler for debugging flows.
+
+Run with:
+
+```bash
+npx ts-node src/debug-ui/index.ts
+```
 
 ### Express Server Example
 
 Located in [`src/express-server/`](src/express-server/), this example exposes a flow via an Express endpoint.
 
+Run with:
+
+```bash
+npx ts-node src/express-server/index.ts
+```
+
 ### Memory Store Example
 
 Located in [`src/memory-store/`](src/memory-store/), this example stores the flow context in memory between runs.
 
+Run with:
+
+```bash
+npx ts-node src/memory-store/index.ts
+```
+
 ### Multi-Agent Example
 
 Located in [`src/multi-agent/`](src/multi-agent/), this example demonstrates agent communication via `MessageBus`.
+
+Run with:
+
+```bash
+npx ts-node src/multi-agent/index.ts
+```
 ### Tool Calls Example
 
 Located in [`src/tool-calls/`](src/tool-calls/), this example demonstrates how to
 invoke a custom tool within a flow.
+
+Run with:
+
+```bash
+npx ts-node src/tool-calls/index.ts
+```
 
 ## Architecture Overview
 
@@ -120,12 +177,12 @@ graph TD
 ## Setup
 
 1. Install dependencies: `npm install`
-2. Run: `npm start`
+2. Run: `npm start` *(runs the observability example)*
 3. Test: `npm test`
 
 ## Scripts
 
-- `npm start`: Run the code
+- `npm start`: Run the observability example
 - `npm run build`: Compile TypeScript
 - `npm run lint`: Run ESLint
 - `npm run test`: Run tests


### PR DESCRIPTION
## Summary
- clarify that `npm start` runs the observability example
- show `npx ts-node` commands for all examples

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fd2b51b4832c978ee682c9cd1a3d