### PR TITLE
Add HTTP request example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ Run with:
 npx ts-node src/tool-calls/index.ts
 ```
 
+### HTTP Request Example
+
+Located in [`src/http-request/`](src/http-request/), this example fetches JSON from an API using `HttpNode`.
+
+Run with:
+
+```bash
+npx ts-node src/http-request/index.ts
+```
+
 ## Architecture Overview
 
 ```mermaid

--- a/src/http-request/README.md
+++ b/src/http-request/README.md
@@ -1,0 +1,7 @@
+# HTTP Request Example
+
+Fetches JSON from a public API using a `HttpNode`.
+
+```bash
+npx ts-node src/http-request/index.ts
+```

--- a/src/http-request/index.ts
+++ b/src/http-request/index.ts
@@ -1,0 +1,25 @@
+import { Flow, Runner, Context } from 'ai-agent-flow';
+import { HttpNode } from 'ai-agent-flow/nodes/http';
+
+async function main() {
+  const fetchNode = new HttpNode('get-todo', {
+    url: 'https://jsonplaceholder.typicode.com/todos/1',
+    method: 'GET',
+  });
+
+  const flow = new Flow('http-flow')
+    .addNode(fetchNode)
+    .setStartNode('get-todo');
+
+  const context: Context = {
+    conversationHistory: [],
+    data: {},
+    metadata: {},
+  };
+
+  const runner = new Runner();
+  const result = await runner.runFlow(flow, context);
+  console.log(result);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add a `http-request` example showing how to fetch JSON with `HttpNode`
- document how to run the new example
- list the example in the main README

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68430207a740832c8a35508ea8118fc9