### PR TITLE
Add Redis option to multi-agent example

### DIFF
--- a/src/multi-agent/README.md
+++ b/src/multi-agent/README.md
@@ -2,6 +2,24 @@
 
 Shows two agents communicating through a `MessageBus`.
 
+## Setup
+
+1. Install and start a Redis server. You can use Docker:
+
+   ```bash
+   docker run -p 6379:6379 -d redis
+   ```
+
+2. Set the `REDIS_URL` environment variable to your Redis instance (defaults to
+   `redis://localhost:6379`):
+
+   ```bash
+   export REDIS_URL=redis://localhost:6379
+   ```
+
+If `REDIS_URL` is not defined or Redis is unavailable, the example falls back to
+the in-memory `MessageBus`.
+
 ```bash
 npx ts-node src/multi-agent/index.ts
 ```

--- a/src/multi-agent/index.ts
+++ b/src/multi-agent/index.ts
@@ -1,7 +1,23 @@
+import dotenv from 'dotenv';
+dotenv.config();
 import { Flow, Runner, Context, MessageBus } from 'ai-agent-flow';
 import { ActionNode } from 'ai-agent-flow/nodes/action';
+import { RedisMessageBus } from 'ai-agent-flow/utils/redis-message-bus';
 
-const bus = new MessageBus();
+let bus: MessageBus;
+if (process.env.REDIS_URL) {
+  try {
+    bus = new RedisMessageBus({ url: process.env.REDIS_URL });
+  } catch (err) {
+    console.warn(
+      'Failed to connect to Redis, falling back to in-memory MessageBus',
+      err
+    );
+    bus = new MessageBus();
+  }
+} else {
+  bus = new MessageBus();
+}
 
 bus.subscribe('agent2', (sender, message) => {
   console.log(`Agent2 received from ${sender}: ${message}`);


### PR DESCRIPTION
## Summary
- enable `RedisMessageBus` when the `REDIS_URL` env var is provided
- document Redis setup in multi-agent README

## Testing
- `npx prettier --write "src/**/*.ts"`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843020c3640832c9ec3a6eb490ea9ff