### PR TITLE
Add multi-flow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ Run with:
 ```bash
 npx ts-node src/multi-agent/index.ts
 ```
+
+### Multi-Flow Example
+
+Located in [`src/multi-flow/`](src/multi-flow/), this example runs multiple flows concurrently.
+
+Run with:
+
+```bash
+npx ts-node src/multi-flow/index.ts
+```
 ### Tool Calls Example
 
 Located in [`src/tool-calls/`](src/tool-calls/), this example demonstrates how to

--- a/src/multi-flow/README.md
+++ b/src/multi-flow/README.md
@@ -1,0 +1,10 @@
+# Multi-Flow Example
+
+Runs two flows concurrently using `Runner.runAgentFlows`.
+
+```bash
+npx ts-node src/multi-flow/index.ts
+```
+
+Expected output shows each flow executing and a map of results printed to the console.
+

--- a/src/multi-flow/index.ts
+++ b/src/multi-flow/index.ts
@@ -1,0 +1,32 @@
+import { Flow, Runner, Context } from 'ai-agent-flow';
+import { ActionNode } from 'ai-agent-flow/nodes/action';
+
+async function main() {
+  const nodeA = new ActionNode('a', async () => {
+    console.log('Running flow A');
+    return { type: 'success', output: 'done A' };
+  });
+
+  const flowA = new Flow('flowA').addNode(nodeA).setStartNode('a');
+
+  const nodeB = new ActionNode('b', async () => {
+    console.log('Running flow B');
+    return { type: 'success', output: 'done B' };
+  });
+
+  const flowB = new Flow('flowB').addNode(nodeB).setStartNode('b');
+
+  const ctxA: Context = { conversationHistory: [], data: {}, metadata: {} };
+  const ctxB: Context = { conversationHistory: [], data: {}, metadata: {} };
+
+  const runner = new Runner();
+  const results = await runner.runAgentFlows(
+    [flowA, flowB],
+    { [flowA.getId()]: ctxA, [flowB.getId()]: ctxB },
+    true,
+  );
+
+  console.log(results);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add `multi-flow` example demonstrating `Runner.runAgentFlows`
- document how to run the new example
- link the multi-flow example from the root README

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6843020e5800832cae871ed9bb709e35