### PR TITLE
Add sample plugin loader

### DIFF
--- a/src/plugin-system/README.md
+++ b/src/plugin-system/README.md
@@ -90,6 +90,34 @@ You can enhance this example by:
 - Creating additional LLM providers (e.g., for local models)
 - Building a plugin registry system for dynamic loading
 
+## Dynamic Plugins
+
+You can load plugins at runtime by passing their paths to the `Runner`
+constructor. A plugin module exports an object with `name` and `setup`.
+
+```javascript
+// src/plugin-system/logger-plugin.js
+module.exports = {
+  default: {
+    name: 'logger',
+    setup(runner) {
+      runner.onUpdate((u) => console.log('[PLUGIN]', u));
+    },
+  },
+};
+```
+
+Load the plugin when creating a runner:
+
+```typescript
+import path from 'node:path';
+import { Runner } from 'ai-agent-flow';
+
+const runner = new Runner(3, 1000, undefined, [
+  path.join(__dirname, 'logger-plugin.js'),
+]);
+```
+
 ## Dependencies
 
 To use all features in this example, you'll need to install:

--- a/src/plugin-system/index.ts
+++ b/src/plugin-system/index.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-function */
 import { Flow, Runner, Context, Node, NodeResult } from 'ai-agent-flow';
 import { ActionNode } from 'ai-agent-flow/nodes/action';
+import path from 'node:path';
 // These imports are commented out to avoid linter errors without the actual packages
 // import { MongoClient } from 'mongodb';
 // import { Anthropic } from '@anthropic-ai/sdk';
@@ -158,8 +159,10 @@ async function runExample() {
   // const completion = await anthropicProvider.generateCompletion('What is the weather like?');
   // console.log('Anthropic completion:', completion);
 
-  // Run the flow
-  const runner = new Runner();
+  // Run the flow with a custom logger plugin
+  const runner = new Runner(3, 1000, undefined, [
+    path.join(__dirname, 'logger-plugin.js'),
+  ]);
   const result = await runner.runFlow(flow, context);
 
   console.log('Flow result:', result);

--- a/src/plugin-system/logger-plugin.js
+++ b/src/plugin-system/logger-plugin.js
@@ -1,0 +1,8 @@
+module.exports = {
+  default: {
+    name: 'logger',
+    setup(runner) {
+      runner.onUpdate((u) => console.log('[PLUGIN]', u));
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add a simple logger plugin example
- load the plugin via `Runner` constructor
- document how to build and load plugins dynamically

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68430213f7ec832cbb29e5a0102b47d3