### PR TITLE
Add example tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ graph TD
 - `npm run test`: Run tests
 - `npm run format`: Run Prettier
 
+## Testing the Examples
+
+Running `npm test` executes a Mocha suite that spawns each short-lived example
+using `npx ts-node`. The tests assert that these scripts exit with status `0`,
+so failures indicate an example crashed or threw an exception. Examples that run
+servers, such as the observability and Express server demos, are excluded from
+the test suite.
+
 ## Inspecting Flows
 
 You can inspect any example without running it by using the CLI that ships with

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'mocha';
+import { spawnSync } from 'child_process';
+import { expect } from 'chai';
+import path from 'node:path';
+
+const examples = [
+  'advanced',
+  'chatbot',
+  'data-pipeline',
+  'debug-ui',
+  'memory-store',
+  'streaming',
+  'tool-calls',
+];
+
+describe('example scripts', function () {
+  this.timeout(60000);
+
+  for (const dir of examples) {
+    it(`runs ${dir} index.ts`, () => {
+      const script = path.join('src', dir, 'index.ts');
+      const result = spawnSync('npx', ['ts-node', script], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? 'test',
+        },
+      });
+
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+
+      expect(result.status).to.equal(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add mocha test to run example scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430da05614832cac3871440386053f