### PR TITLE
Add startServer export for express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Located in [`src/express-server/`](src/express-server/), this example exposes a 
 Run with:
 
 ```bash
-npx ts-node src/express-server/index.ts
+npx ts-node -e "import { startServer } from './src/express-server/index.ts'; startServer();"
 ```
 
 ### Memory Store Example

--- a/src/express-server/README.md
+++ b/src/express-server/README.md
@@ -3,5 +3,5 @@
 Exposes a flow result at `http://localhost:3000/flow` using Express.
 
 ```bash
-npx ts-node src/express-server/index.ts
+npx ts-node -e "import { startServer } from './src/express-server/index.ts'; startServer();"
 ```

--- a/src/express-server/index.ts
+++ b/src/express-server/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { Flow, Runner, Context } from 'ai-agent-flow';
 import { ActionNode } from 'ai-agent-flow/nodes/action';
+import { Server } from 'http';
 
 const greetNode = new ActionNode('greet', async () => ({
   type: 'success',
@@ -11,13 +12,20 @@ const flow = new Flow('express-flow').addNode(greetNode).setStartNode('greet');
 
 const runner = new Runner();
 
-const app = express();
-app.get('/flow', async (_req, res) => {
-  const context: Context = { conversationHistory: [], data: {}, metadata: {} };
-  const result = await runner.runFlow(flow, context);
-  res.json(result);
-});
+function createApp() {
+  const app = express();
+  app.get('/flow', async (_req, res) => {
+    const context: Context = { conversationHistory: [], data: {}, metadata: {} };
+    const result = await runner.runFlow(flow, context);
+    res.json(result);
+  });
+  return app;
+}
 
-app.listen(3000, () => {
-  console.log('Server running at http://localhost:3000/flow');
-});
+export function startServer(port = 3000): Server {
+  const app = createApp();
+  const server = app.listen(port, () => {
+    console.log(`Server running at http://localhost:${port}/flow`);
+  });
+  return server;
+}

--- a/tests/express-server.test.ts
+++ b/tests/express-server.test.ts
@@ -1,0 +1,23 @@
+import { strict as assert } from 'assert';
+import { describe, it, before, after } from 'mocha';
+
+let startServer: any;
+
+describe('express server', function () {
+  let server: any;
+  before(() => {
+    process.env.OPENAI_API_KEY = 'dummy';
+    ({ startServer } = require('../src/express-server/index.ts'));
+    server = startServer(3001);
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('returns flow result', async function () {
+    const response = await fetch('http://localhost:3001/flow');
+    const json = await response.json();
+    assert.equal(json.type, 'success');
+  });
+});


### PR DESCRIPTION
## Summary
- expose `startServer()` from Express example
- update README snippets to show how to start the server programmatically
- add a mocha test to start and stop the Express server

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68431127273c832c8a844f4b02f710f8