### PR TITLE
Expose start() for observability example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,20 @@ To run the observability example:
 
 1. Install dependencies: `npm install`
 2. Run: `npm start`
-3. Access metrics at `http://localhost:3000/metrics`
+3. Access metrics at `http://localhost:9100/metrics`
 
 `npm start` executes this observability example. Use `npx ts-node` for the
 other examples.
+
+Programmatic usage:
+
+```ts
+import { start } from './src/observability/index';
+
+const { server, runPromise } = start();
+await runPromise;
+server.close();
+```
 
 ### Plugin System Example
 

--- a/src/observability/README.md
+++ b/src/observability/README.md
@@ -15,6 +15,18 @@ npx ts-node src/observability/index.ts
 
 Then visit: http://localhost:9100/metrics
 
+### Programmatic Usage
+
+You can also start the server from your own code:
+
+```ts
+import { start } from './src/observability/index';
+
+const { server, runPromise } = start();
+await runPromise;
+server.close();
+```
+
 ## What You'll See
 
 - Node executions logged to the console with Winston

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+process.env.OPENAI_API_KEY = 'dummy';
+import { start } from '../src/observability/index';
+
+describe('observability start', () => {
+  it('runs the flow and closes the server', async () => {
+    const { server, runPromise } = start();
+    const result = await runPromise;
+    expect(result).to.deep.equal({
+      type: 'success',
+      output: 'Flow completed'
+    });
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});


### PR DESCRIPTION
## Summary
- refactor `src/observability/index.ts` so `app.listen` returns the server instance
- export a `start()` helper
- document how to use `start()` programmatically
- add a mocha test demonstrating `start()` and closing the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431126ac4c832ca541c1c03d807b1a