### PR TITLE
Fix framework URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Agent Flow Examples
 
-This repository contains example implementations and usage patterns for the [AI Agent Flow](https://github.com/your-org/ai-agent-flow) framework. Each example demonstrates different features and capabilities of the framework.
+This repository contains example implementations and usage patterns for the [AI Agent Flow](https://github.com/EunixTech/ai-agent-flow) framework ([available on npm](https://www.npmjs.com/package/ai-agent-flow)). Each example demonstrates different features and capabilities of the framework.
 
 The package is published to npm under the name `ai-agent-flow-examples`.
 


### PR DESCRIPTION
## Summary
- fix the GitHub URL to point to `EunixTech/ai-agent-flow`
- link to the `ai-agent-flow` npm page in the intro

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684317284a18832c8f3e3b39640baafa