### PR TITLE
Add Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,44 @@
 
 This repository contains example implementations and usage patterns for the [AI Agent Flow](https://github.com/EunixTech/ai-agent-flow) framework ([available on npm](https://www.npmjs.com/package/ai-agent-flow)). Each example demonstrates different features and capabilities of the framework.
 
+
 The package is published to npm as [`ai-agent-flow-examples`](https://www.npmjs.com/package/ai-agent-flow-examples).
 
+## Quick Start
+
+Create `src/quick-start.ts` with a minimal flow:
+
+```ts
+import { Flow, Runner } from 'ai-agent-flow';
+import { ActionNode } from 'ai-agent-flow/nodes/action';
+
+const helloNode = new ActionNode('start', async () => ({
+  type: 'success',
+  output: 'Hello world'
+}));
+
+const flow = new Flow('quick-start')
+  .addNode(helloNode)
+  .setStartNode('start');
+
+const context = { conversationHistory: [], data: {}, metadata: {} };
+
+new Runner().runFlow(flow, context).then(console.log);
+```
+
+Then run it with:
+
+```bash
+npm install
+npx ts-node examples/quick-start.ts
+```
+
+
 ## Examples
+
+### Quick Start
+
+See the [Quick Start](#quick-start) section for a minimal example.
 
 ### Observability Example
 

--- a/examples/quick-start.ts
+++ b/examples/quick-start.ts
@@ -1,0 +1,1 @@
+import '../src/quick-start';

--- a/src/quick-start.ts
+++ b/src/quick-start.ts
@@ -1,0 +1,19 @@
+import { Flow, Runner } from 'ai-agent-flow';
+import { ActionNode } from 'ai-agent-flow/nodes/action';
+
+async function main() {
+  const helloNode = new ActionNode('start', async () => ({
+    type: 'success',
+    output: 'Hello world'
+  }));
+
+  const flow = new Flow('quick-start')
+    .addNode(helloNode)
+    .setStartNode('start');
+
+  const context = { conversationHistory: [], data: {}, metadata: {} };
+  const result = await new Runner().runFlow(flow, context);
+  console.log(result);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add Quick Start section with simple Flow snippet
- link the Quick Start section from the examples list
- include npm commands to run the sample
- add the Quick Start code under `src` and thin wrapper under `examples`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68431f713b70832c8bd661c7c2d4e9e9