### PR TITLE
Add interactive CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,16 @@ Run with:
 npx ts-node src/http-request/index.ts
 ```
 
+### Interactive CLI Example
+
+Located in [`src/interactive-cli/`](src/interactive-cli/), this example runs a conversational loop in your terminal.
+
+Run with:
+
+```bash
+npx ts-node src/interactive-cli/index.ts
+```
+
 ## Architecture Overview
 
 ```mermaid

--- a/src/interactive-cli/README.md
+++ b/src/interactive-cli/README.md
@@ -1,0 +1,7 @@
+# Interactive CLI Example
+
+A simple command-line chat loop that keeps conversation history and replies using an `LLMNode`.
+
+```bash
+npx ts-node src/interactive-cli/index.ts
+```

--- a/src/interactive-cli/index.ts
+++ b/src/interactive-cli/index.ts
@@ -1,0 +1,43 @@
+import dotenv from 'dotenv';
+dotenv.config();
+import readline from 'node:readline';
+import { Flow, Runner, Context } from 'ai-agent-flow';
+import { LLMNode } from 'ai-agent-flow/nodes/llm';
+import { OpenAI } from 'openai';
+
+// Initialize OpenAI with API key from environment
+new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function main() {
+  const chatNode = new LLMNode('chat', (ctx) => ctx.data.userInput as string);
+  const flow = new Flow('interactive-cli')
+    .addNode(chatNode)
+    .setStartNode('chat');
+
+  const context: Context = { conversationHistory: [], data: {}, metadata: {} };
+  const runner = new Runner();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  console.log('Type "exit" to quit.');
+
+  const ask = () => {
+    rl.question('You> ', async (line) => {
+      if (line.trim().toLowerCase() === 'exit') {
+        rl.close();
+        return;
+      }
+      context.data.userInput = line;
+      const result = await runner.runFlow(flow, context);
+      if (result.type === 'success') {
+        console.log('Bot>', result.output);
+      } else {
+        console.error('Error:', result.error);
+      }
+      ask();
+    });
+  };
+
+  ask();
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- add `interactive-cli` example with readline loop
- document usage in `src/interactive-cli/README.md`
- reference the new example in the root README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843217ed780832ca14f7e3a7ec06125