### PR TITLE
Add example script shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then run it with:
 
 ```bash
 npm install
-npx ts-node examples/quick-start.ts
+npm run example examples/quick-start.ts
 ```
 
 
@@ -64,8 +64,8 @@ To run the observability example:
 2. Run: `npm start`
 3. Access metrics at `http://localhost:9100/metrics`
 
-`npm start` executes this observability example. Use `npx ts-node` for the
-other examples.
+`npm start` executes this observability example. Use `npm run example <path>`
+for the other examples.
 
 Programmatic usage:
 
@@ -99,7 +99,7 @@ graph LR
 Run with:
 
 ```bash
-npx ts-node src/plugin-system/index.ts
+npm run example src/plugin-system/index.ts
 ```
 
 ### Streaming Example
@@ -122,7 +122,7 @@ graph TD
 To run the streaming example:
 
 1. Set up your OpenAI API key in `.env`
-2. Run: `npx ts-node src/streaming/index.ts`
+2. Run: `npm run example src/streaming/index.ts`
 
 
 ### Advanced Example
@@ -132,7 +132,7 @@ Located in [`src/advanced/`](src/advanced/), this example shows conditional bran
 Run with:
 
 ```bash
-npx ts-node src/advanced/index.ts
+npm run example src/advanced/index.ts
 ```
 
 ### Chatbot Example
@@ -142,7 +142,7 @@ Located in [`src/chatbot/`](src/chatbot/), this is a tiny chatbot that tracks co
 Run with:
 
 ```bash
-npx ts-node src/chatbot/index.ts
+npm run example src/chatbot/index.ts
 ```
 
 ### Data Pipeline Example
@@ -152,7 +152,7 @@ Located in [`src/data-pipeline/`](src/data-pipeline/), this example processes it
 Run with:
 
 ```bash
-npx ts-node src/data-pipeline/index.ts
+npm run example src/data-pipeline/index.ts
 ```
 
 ### Debug UI Example
@@ -162,7 +162,7 @@ Located in [`src/debug-ui/`](src/debug-ui/), this example attaches an update han
 Run with:
 
 ```bash
-npx ts-node src/debug-ui/index.ts
+npm run example src/debug-ui/index.ts
 ```
 
 ### Express Server Example
@@ -172,7 +172,7 @@ Located in [`src/express-server/`](src/express-server/), this example exposes a 
 Run with:
 
 ```bash
-npx ts-node -e "import { startServer } from './src/express-server/index.ts'; startServer();"
+npm run example -e "import { startServer } from './src/express-server/index.ts'; startServer();"
 ```
 
 ### Memory Store Example
@@ -182,7 +182,7 @@ Located in [`src/memory-store/`](src/memory-store/), this example stores the flo
 Run with:
 
 ```bash
-npx ts-node src/memory-store/index.ts
+npm run example src/memory-store/index.ts
 ```
 
 ### Multi-Agent Example
@@ -192,7 +192,7 @@ Located in [`src/multi-agent/`](src/multi-agent/), this example demonstrates age
 Run with:
 
 ```bash
-npx ts-node src/multi-agent/index.ts
+npm run example src/multi-agent/index.ts
 ```
 
 ### Multi-Flow Example
@@ -202,7 +202,7 @@ Located in [`src/multi-flow/`](src/multi-flow/), this example runs multiple flow
 Run with:
 
 ```bash
-npx ts-node src/multi-flow/index.ts
+npm run example src/multi-flow/index.ts
 ```
 ### Tool Calls Example
 
@@ -212,7 +212,7 @@ invoke a custom tool within a flow.
 Run with:
 
 ```bash
-npx ts-node src/tool-calls/index.ts
+npm run example src/tool-calls/index.ts
 ```
 
 ### HTTP Request Example
@@ -222,7 +222,7 @@ Located in [`src/http-request/`](src/http-request/), this example fetches JSON f
 Run with:
 
 ```bash
-npx ts-node src/http-request/index.ts
+npm run example src/http-request/index.ts
 ```
 
 ### Interactive CLI Example
@@ -232,7 +232,7 @@ Located in [`src/interactive-cli/`](src/interactive-cli/), this example runs a c
 Run with:
 
 ```bash
-npx ts-node src/interactive-cli/index.ts
+npm run example src/interactive-cli/index.ts
 ```
 
 ## Architecture Overview
@@ -269,7 +269,7 @@ graph TD
 ## Testing the Examples
 
 Running `npm test` executes a Mocha suite that spawns each short-lived example
-using `npx ts-node`. The tests assert that these scripts exit with status `0`,
+using `npm run example`. The tests assert that these scripts exit with status `0`,
 so failures indicate an example crashed or threw an exception. Examples that run
 servers, such as the observability and Express server demos, are excluded from
 the test suite.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "ts-node src/observability/index.ts",
+    "example": "ts-node",
     "build": "tsc",
     "lint": "eslint . --ext .ts",
     "test": "mocha -r ts-node/register tests/**/*.test.ts",

--- a/src/advanced/README.md
+++ b/src/advanced/README.md
@@ -3,5 +3,5 @@
 This example demonstrates conditional branching using a `DecisionNode`.
 
 ```bash
-npx ts-node src/advanced/index.ts
+npm run example src/advanced/index.ts
 ```

--- a/src/chatbot/README.md
+++ b/src/chatbot/README.md
@@ -3,5 +3,5 @@
 A minimal chatbot that responds to greetings and saves conversation history.
 
 ```bash
-npx ts-node src/chatbot/index.ts
+npm run example src/chatbot/index.ts
 ```

--- a/src/data-pipeline/README.md
+++ b/src/data-pipeline/README.md
@@ -3,5 +3,5 @@
 Processes a list of numbers using a `BatchNode` that doubles each item.
 
 ```bash
-npx ts-node src/data-pipeline/index.ts
+npm run example src/data-pipeline/index.ts
 ```

--- a/src/debug-ui/README.md
+++ b/src/debug-ui/README.md
@@ -3,5 +3,5 @@
 Shows how to log flow updates using `runner.onUpdate()`.
 
 ```bash
-npx ts-node src/debug-ui/index.ts
+npm run example src/debug-ui/index.ts
 ```

--- a/src/express-server/README.md
+++ b/src/express-server/README.md
@@ -3,5 +3,5 @@
 Exposes a flow result at `http://localhost:3000/flow` using Express.
 
 ```bash
-npx ts-node -e "import { startServer } from './src/express-server/index.ts'; startServer();"
+npm run example -e "import { startServer } from './src/express-server/index.ts'; startServer();"
 ```

--- a/src/http-request/README.md
+++ b/src/http-request/README.md
@@ -3,5 +3,5 @@
 Fetches JSON from a public API using a `HttpNode`.
 
 ```bash
-npx ts-node src/http-request/index.ts
+npm run example src/http-request/index.ts
 ```

--- a/src/interactive-cli/README.md
+++ b/src/interactive-cli/README.md
@@ -3,5 +3,5 @@
 A simple command-line chat loop that keeps conversation history and replies using an `LLMNode`.
 
 ```bash
-npx ts-node src/interactive-cli/index.ts
+npm run example src/interactive-cli/index.ts
 ```

--- a/src/memory-store/README.md
+++ b/src/memory-store/README.md
@@ -3,5 +3,5 @@
 Persists context between runs using an in-memory Map.
 
 ```bash
-npx ts-node src/memory-store/index.ts
+npm run example src/memory-store/index.ts
 ```

--- a/src/multi-agent/README.md
+++ b/src/multi-agent/README.md
@@ -21,5 +21,5 @@ If `REDIS_URL` is not defined or Redis is unavailable, the example falls back to
 the in-memory `MessageBus`.
 
 ```bash
-npx ts-node src/multi-agent/index.ts
+npm run example src/multi-agent/index.ts
 ```

--- a/src/multi-flow/README.md
+++ b/src/multi-flow/README.md
@@ -3,7 +3,7 @@
 Runs two flows concurrently using `Runner.runAgentFlows`.
 
 ```bash
-npx ts-node src/multi-flow/index.ts
+npm run example src/multi-flow/index.ts
 ```
 
 Expected output shows each flow executing and a map of results printed to the console.

--- a/src/observability/README.md
+++ b/src/observability/README.md
@@ -10,7 +10,7 @@ This example demonstrates how to integrate observability features into your AI a
 
 ```bash
 npm install
-npx ts-node src/observability/index.ts
+npm run example src/observability/index.ts
 ```
 
 Then visit: http://localhost:9100/metrics

--- a/src/plugin-system/README.md
+++ b/src/plugin-system/README.md
@@ -10,7 +10,7 @@ This example demonstrates how to extend the AI Agent Flow framework with custom 
 
 ```bash
 npm install
-npx ts-node src/plugin-system/index.ts
+npm run example src/plugin-system/index.ts
 ```
 
 To enable MongoDB and Anthropic integrations, install the extra packages and
@@ -34,14 +34,14 @@ graph TD
 1. **Basic Testing**:
    ```bash
    # Run the example with default settings
-   npx ts-node src/plugin-system/index.ts
+   npm run example src/plugin-system/index.ts
    ```
    You should see output showing the WeatherNode executing and the flow result.
 
 2. **Running the Test Script**:
    ```bash
    # Run the dedicated test script
-   npx ts-node src/plugin-system/test.ts
+   npm run example src/plugin-system/test.ts
    ```
    This script provides a more focused test of the custom components with detailed output.
 
@@ -137,7 +137,7 @@ After installing the extra packages and uncommenting the lines mentioned above,
 run the example with:
 
 ```bash
-npx ts-node src/plugin-system/index.ts
+npm run example src/plugin-system/index.ts
 ```
 
 ## Troubleshooting

--- a/src/streaming/README.md
+++ b/src/streaming/README.md
@@ -28,7 +28,7 @@ This example demonstrates how to use streaming responses from OpenAI using the A
 
 3. Run the example:
    ```bash
-   npx ts-node src/streaming/index.ts
+   npm run example src/streaming/index.ts
    ```
 
 ## What to Expect

--- a/src/tool-calls/README.md
+++ b/src/tool-calls/README.md
@@ -3,5 +3,5 @@
 This example demonstrates how to call a custom tool within an AI Agent Flow. The flow contains an `ActionNode` that converts an input string to uppercase.
 
 ```bash
-npx ts-node src/tool-calls/index.ts
+npm run example src/tool-calls/index.ts
 ```


### PR DESCRIPTION
## Summary
- add `example` npm script
- update docs to use `npm run example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684324c66ebc832cafff2c8bb57ccb20